### PR TITLE
Add F11 fullscreen toggle

### DIFF
--- a/src/keyboard/keybindings.rs
+++ b/src/keyboard/keybindings.rs
@@ -1,5 +1,5 @@
 use gtk4::{
-    gdk::{Event, KeyMatch, ModifierType},
+    gdk::{Event, KeyMatch},
     ShortcutTrigger,
 };
 use libadwaita::prelude::*;
@@ -56,6 +56,8 @@ pub struct Keybindings {
     open_editor_cwd: String,
     #[serde(default = "default_clear_scrollback")]
     clear_scrollback: String,
+    #[serde(default = "default_toggle_fullscreen")]
+    toggle_fullscreen: String,
 }
 
 impl Keybindings {
@@ -140,6 +142,11 @@ impl Keybindings {
             KeyboardAction::ClearScrollback,
             "Clear Tmux scrollback",
         ));
+        keybindings.push(Keybinding::new(
+            &self.toggle_fullscreen,
+            KeyboardAction::ToggleFullscreen,
+            "Toggle fullscreen mode",
+        ));
 
         keybindings
     }
@@ -169,6 +176,7 @@ impl Keybindings {
                 KeyboardAction::PasteClipboard => self.paste_clipboard = trigger,
                 KeyboardAction::OpenEditorCwd => self.open_editor_cwd = trigger,
                 KeyboardAction::ClearScrollback => self.clear_scrollback = trigger,
+                KeyboardAction::ToggleFullscreen => self.toggle_fullscreen = trigger,
             }
         }
     }
@@ -179,14 +187,6 @@ pub fn check_keybinding_match(
     keybindings: &Vec<Keybinding>,
     event: Event,
 ) -> Option<KeyboardAction> {
-    let state = event.modifier_state();
-    if !state.contains(ModifierType::CONTROL_MASK)
-        && !state.contains(ModifierType::SHIFT_MASK)
-        && !state.contains(ModifierType::ALT_MASK)
-    {
-        return None;
-    }
-
     for keybinding in keybindings {
         if let Some(trigger) = &keybinding.trigger {
             if trigger.trigger(&event, true) == KeyMatch::Exact {
@@ -217,6 +217,7 @@ impl Default for Keybindings {
             paste_clipboard: default_paste_clipboard(),
             open_editor_cwd: default_open_editor_cwd(),
             clear_scrollback: default_clear_scrollback(),
+            toggle_fullscreen: default_toggle_fullscreen(),
         }
     }
 }
@@ -265,4 +266,7 @@ fn default_open_editor_cwd() -> String {
 }
 fn default_clear_scrollback() -> String {
     "<Ctrl><Shift>h".to_string()
+}
+fn default_toggle_fullscreen() -> String {
+    "F11".to_string()
 }

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -21,6 +21,7 @@ pub enum KeyboardAction {
     // TODO: Correct naming
     MoveFocus(Direction),
     ToggleZoom,
+    ToggleFullscreen,
     CopySelected,
     PasteClipboard,
     OpenEditorCwd,

--- a/src/normal_widgets/terminal/mod.rs
+++ b/src/normal_widgets/terminal/mod.rs
@@ -270,5 +270,17 @@ fn handle_keyboard(action: KeyboardAction, terminal: &Terminal, top_level: &TopL
             let clear_scrollback = [b'\x1b', b'[', b'3', b'J'];
             vte.feed(&clear_scrollback);
         }
+        KeyboardAction::ToggleFullscreen => {
+            if let Some(window) = top_level
+                .root()
+                .and_then(|r| r.downcast::<gtk4::Window>().ok())
+            {
+                if window.is_fullscreen() {
+                    window.unfullscreen();
+                } else {
+                    window.fullscreen();
+                }
+            }
+        }
     }
 }

--- a/src/settings_window/keybindings/mod.rs
+++ b/src/settings_window/keybindings/mod.rs
@@ -2,8 +2,9 @@ mod imp;
 
 use glib::{Object, Propagation};
 use gtk4::{
-    gdk::ModifierType, glib, Align, Box, EventControllerKey, GestureClick, Label, Orientation,
-    ShortcutTrigger,
+    gdk::{Key, ModifierType},
+    glib,
+    Align, Box, EventControllerKey, GestureClick, Label, Orientation, ShortcutTrigger,
 };
 use libadwaita::{prelude::*, subclass::prelude::*, PreferencesGroup, PreferencesRow};
 
@@ -43,6 +44,25 @@ impl KeybindingPage {
             move |_, keyval, keycode, state| {
                 let unicode = keyval.to_unicode();
                 if unicode.is_none() {
+                    // Handle function keys (F1-F12) and other non-printable keys
+                    match keycode {
+                        9 => {
+                            // Handle ESCAPE - ignore
+                            page.user_keyboard_input(None);
+                        }
+                        22 => {
+                            // Handle Backspace - unassign keybinding
+                            page.user_keyboard_input(Some(""));
+                        }
+                        _ => {
+                            // Try to handle function keys
+                            if let Some(trigger) = fn_key_to_trigger(keyval, state) {
+                                page.user_keyboard_input(Some(&trigger));
+                            } else {
+                                page.user_keyboard_input(None);
+                            }
+                        }
+                    }
                     return Propagation::Stop;
                 }
                 let unicode = unicode.unwrap();
@@ -233,6 +253,38 @@ fn set_text_from_trigger(label: &Label, trigger: &Option<ShortcutTrigger>) {
     } else {
         label.set_label("");
     }
+}
+
+#[inline]
+fn fn_key_to_trigger(keyval: Key, state: ModifierType) -> Option<String> {
+    let key_name = match keyval {
+        Key::F1 => "F1",
+        Key::F2 => "F2",
+        Key::F3 => "F3",
+        Key::F4 => "F4",
+        Key::F5 => "F5",
+        Key::F6 => "F6",
+        Key::F7 => "F7",
+        Key::F8 => "F8",
+        Key::F9 => "F9",
+        Key::F10 => "F10",
+        Key::F11 => "F11",
+        Key::F12 => "F12",
+        _ => return None,
+    };
+
+    let mut ret = String::new();
+    if state.contains(ModifierType::CONTROL_MASK) {
+        ret.push_str("<Ctrl>");
+    }
+    if state.contains(ModifierType::SHIFT_MASK) {
+        ret.push_str("<Shift>");
+    }
+    if state.contains(ModifierType::ALT_MASK) {
+        ret.push_str("<Alt>");
+    }
+    ret.push_str(key_name);
+    Some(ret)
 }
 
 #[inline]

--- a/src/tmux_api/send.rs
+++ b/src/tmux_api/send.rs
@@ -182,6 +182,10 @@ impl TmuxAPI {
                 let cmd = format!("clear-history -t %{}", pane_id);
                 (event, cmd)
             }
+            KeyboardAction::ToggleFullscreen => {
+                // Fullscreen is handled by the GTK window, not tmux
+                return Ok(());
+            }
         };
 
         self.send_event(event, &cmd)

--- a/src/tmux_widgets/terminal/mod.rs
+++ b/src/tmux_widgets/terminal/mod.rs
@@ -250,6 +250,13 @@ fn handle_keyboard_event(
         KeyboardAction::TabRename => {
             top_level.open_rename_modal();
         }
+        KeyboardAction::ToggleFullscreen => {
+            if window.is_fullscreen() {
+                window.unfullscreen();
+            } else {
+                window.fullscreen();
+            }
+        }
         _ => {
             window.tmux_handle_keybinding(action, pane_id);
         }


### PR DESCRIPTION
## Summary

- Adds a `ToggleFullscreen` keyboard action (default `F11`) that calls GTK's `fullscreen()`/`unfullscreen()` on the active window
- Works in both normal and tmux window modes
- Keybinding is configurable via the Settings → Keybindings UI, including modifier+F-key combos (e.g. `<Alt>F11`)
- Also fixes the modifier-key early-return guard in `check_keybinding_match` so that modifier-free keys like F11 are checked against registered keybindings rather than passed straight through to the VTE widget

## Changes

- `src/keyboard/mod.rs` — add `ToggleFullscreen` to `KeyboardAction` enum
- `src/keyboard/keybindings.rs` — add `toggle_fullscreen` field (default `"F11"`); remove the modifier early-return guard in `check_keybinding_match` (the guard was silently swallowing all modifier-free key events before they could match any keybinding)
- `src/normal_widgets/terminal/mod.rs` — handle `ToggleFullscreen` via `top_level.root()` downcast to `gtk4::Window`
- `src/tmux_widgets/terminal/mod.rs` — handle `ToggleFullscreen` directly on the window
- `src/tmux_api/send.rs` — return `Ok(())` early for `ToggleFullscreen` (GTK-only, not a tmux command)
- `src/settings_window/keybindings/mod.rs` — add `fn_key_to_trigger` so F1–F12 keys can be rebound in the Settings UI

## Test plan

- [ ] Press `F11` in a normal terminal window — window should enter fullscreen
- [ ] Press `F11` again — window should exit fullscreen
- [ ] Press `F11` in a tmux window — same behaviour
- [ ] Open Settings → Keybindings, double-click the "Toggle fullscreen mode" row and press a new key combo to confirm rebinding works

🤖 Generated with [Claude Code](https://claude.com/claude-code)